### PR TITLE
Fix for duplicate key bug

### DIFF
--- a/Snap2HTML/CommandLine.cs
+++ b/Snap2HTML/CommandLine.cs
@@ -118,9 +118,9 @@ namespace CommandLine.Utility
                         //Because of the split index 0 will be a empty string
                         string valuesWithoutQuotes = RemoveMatchingQuotes(parts[2]);
 
-						// MOD: Don't split on commas
+                        // MOD: Don't split on commas
                         //AddListValues(parts[1], valuesWithoutQuotes.Split(','));
-						Add( parts[1], valuesWithoutQuotes );
+                        Add( parts[1], valuesWithoutQuotes );
                         break;
                 }
             }

--- a/Snap2HTML/Settings.cs
+++ b/Snap2HTML/Settings.cs
@@ -1,9 +1,9 @@
 ﻿namespace Snap2HTML.Properties {    
-    // This class allows you to handle specific events on the settings class:
-    //  The SettingChanging event is raised before a setting's value is changed.
-    //  The PropertyChanged event is raised after a setting's value is changed.
-    //  The SettingsLoaded event is raised after the setting values are loaded.
-    //  The SettingsSaving event is raised before the setting values are saved.
+	// This class allows you to handle specific events on the settings class:
+	//  The SettingChanging event is raised before a setting's value is changed.
+	//  The PropertyChanged event is raised after a setting's value is changed.
+	//  The SettingsLoaded event is raised after the setting values are loaded.
+	//  The SettingsSaving event is raised before the setting values are saved.
 	internal sealed partial class Settings
 	{
 		public Settings()

--- a/Snap2HTML/app.config
+++ b/Snap2HTML/app.config
@@ -36,4 +36,7 @@
             </setting>
         </Snap2HTML.Properties.Settings>
     </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+	</startup>
+</configuration>

--- a/Snap2HTML/frmMain.cs
+++ b/Snap2HTML/frmMain.cs
@@ -151,7 +151,15 @@ namespace Snap2HTML
 
 		private void cmdBrowse_Click(object sender, EventArgs e)
         {
-			folderBrowserDialog1.RootFolder = Environment.SpecialFolder.Desktop;	// this makes it possible to select network paths too
+			folderBrowserDialog1.RootFolder = Environment.SpecialFolder.Desktop;    // this makes it possible to select network paths too
+
+			// Use the following registry key when some network shares do not show up in the dialog
+			// and reboot the system to apply the change.
+            //Windows Registry Editor Version 5.00
+
+            //[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System]
+            //         "EnableLinkedConnections" = dword:00000001
+
 			folderBrowserDialog1.SelectedPath = txtRoot.Text;
             if (folderBrowserDialog1.ShowDialog() == DialogResult.OK)
 			{

--- a/Snap2HTML/frmMain.cs
+++ b/Snap2HTML/frmMain.cs
@@ -9,15 +9,15 @@ using CommandLine.Utility;
 
 namespace Snap2HTML
 {
-    public partial class frmMain : Form
-    {
+	public partial class frmMain : Form
+	{
 		private bool initDone = false;
 		private bool runningAutomated = false;
 
-        public frmMain()
-        {
-            InitializeComponent();
-        }
+		public frmMain()
+		{
+			InitializeComponent();
+		}
 
 		private void frmMain_Load( object sender, EventArgs e )
 		{
@@ -58,14 +58,14 @@ namespace Snap2HTML
 		}
 
 		private void frmMain_Shown( object sender, EventArgs e )
-        {
-            // parse command line
-            var commandLine = Environment.CommandLine;
+		{
+			// parse command line
+			var commandLine = Environment.CommandLine;
 			commandLine = commandLine.Replace( "-output:", "-outfile:" );	// correct wrong parameter to avoid confusion
-            var splitCommandLine = Arguments.SplitCommandLine(commandLine);
-            var arguments = new Arguments(splitCommandLine);
+			var splitCommandLine = Arguments.SplitCommandLine(commandLine);
+			var arguments = new Arguments(splitCommandLine);
 
-            // first test for single argument (ie path only)
+			// first test for single argument (ie path only)
 			if( splitCommandLine.Length == 2 && !arguments.Exists( "path" ) )
 			{
 				if( System.IO.Directory.Exists( splitCommandLine[1] ) )
@@ -76,7 +76,7 @@ namespace Snap2HTML
 
 			var settings = new SnapSettings();
 			if( arguments.Exists( "path" ) && arguments.Exists( "outfile" ) )
-            {
+			{
 				this.runningAutomated = true;
 
 				settings.rootFolder = arguments.Single( "path" );
@@ -119,7 +119,7 @@ namespace Snap2HTML
 					settings.title = arguments.Single( "title" );
 				}
 
-            }
+			}
 
 			// keep window hidden in silent mode
 			if( arguments.IsTrue( "silent" ) && this.runningAutomated )
@@ -135,7 +135,7 @@ namespace Snap2HTML
 			{
 				StartProcessing( settings );
 			}
-        }
+		}
 
 		private void frmMain_FormClosing( object sender, FormClosingEventArgs e )
 		{
@@ -150,18 +150,18 @@ namespace Snap2HTML
 		}
 
 		private void cmdBrowse_Click(object sender, EventArgs e)
-        {
+		{
 			folderBrowserDialog1.RootFolder = Environment.SpecialFolder.Desktop;    // this makes it possible to select network paths too
 
 			// Use the following registry key when some network shares do not show up in the dialog
 			// and reboot the system to apply the change.
-            //Windows Registry Editor Version 5.00
+			//Windows Registry Editor Version 5.00
 
-            //[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System]
-            //         "EnableLinkedConnections" = dword:00000001
+			//[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System]
+			//         "EnableLinkedConnections" = dword:00000001
 
 			folderBrowserDialog1.SelectedPath = txtRoot.Text;
-            if (folderBrowserDialog1.ShowDialog() == DialogResult.OK)
+			if (folderBrowserDialog1.ShowDialog() == DialogResult.OK)
 			{
 				try
 				{
@@ -172,10 +172,10 @@ namespace Snap2HTML
 					MessageBox.Show( "Could not select folder:\n\n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error );
 					SetRootPath( "", false );
 				}
-            }
-        }
+			}
+		}
 
-        private void cmdCreate_Click(object sender, EventArgs e)
+		private void cmdCreate_Click(object sender, EventArgs e)
 		{
 			// ask for output file
 			string fileName = new System.IO.DirectoryInfo( txtRoot.Text + @"\" ).Name;
@@ -185,13 +185,13 @@ namespace Snap2HTML
 				fileName = fileName.Replace(invalid[i].ToString(), "");
 			}
 
-            saveFileDialog1.DefaultExt = "html";
+			saveFileDialog1.DefaultExt = "html";
 			if( !fileName.ToLower().EndsWith( ".html" ) ) fileName += ".html";
 			saveFileDialog1.FileName = fileName;
 			saveFileDialog1.Filter = "HTML files (*.html)|*.html|All files (*.*)|*.*";
-            saveFileDialog1.InitialDirectory = System.IO.Path.GetDirectoryName(txtRoot.Text);
+			saveFileDialog1.InitialDirectory = System.IO.Path.GetDirectoryName(txtRoot.Text);
 			saveFileDialog1.CheckPathExists = true;
-            if (saveFileDialog1.ShowDialog() != DialogResult.OK) return;
+			if (saveFileDialog1.ShowDialog() != DialogResult.OK) return;
 
 			if( !saveFileDialog1.FileName.ToLower().EndsWith( ".html" ) ) saveFileDialog1.FileName += ".html";
 
@@ -264,13 +264,13 @@ namespace Snap2HTML
 			}
 		}
 
-        private void chkLinkFiles_CheckedChanged(object sender, EventArgs e)
-        {
-            if (chkLinkFiles.Checked == true)
-                txtLinkRoot.Enabled = true;
-            else
-                txtLinkRoot.Enabled = false;
-        }
+		private void chkLinkFiles_CheckedChanged(object sender, EventArgs e)
+		{
+			if (chkLinkFiles.Checked == true)
+				txtLinkRoot.Enabled = true;
+			else
+				txtLinkRoot.Enabled = false;
+		}
 
 		// Link Label handlers
 		private void linkLabel1_LinkClicked( object sender, LinkLabelLinkClickedEventArgs e )
@@ -368,5 +368,5 @@ namespace Snap2HTML
 			}
 		}
 
-    }
+	}
 }

--- a/Snap2HTML/frmMain_BackgroundWorker.cs
+++ b/Snap2HTML/frmMain_BackgroundWorker.cs
@@ -349,30 +349,33 @@ namespace Snap2HTML
 
 			// Build a lookup table with subfolder IDs for each folder
 			var subdirs = new Dictionary<string, List<string>>();
-			foreach( var dir in content )
-			{
-				// add all folders as keys
-				subdirs.Add( dir.GetFullPath(), new List<string>() );
-			}
+
 			if( !subdirs.ContainsKey( content[0].Path ) && content[0].Name != "" )
 			{
 				// ensure that root folder is not missed missed
 				subdirs.Add( content[0].Path, new List<string>() );
 			}
-			foreach( var dirInfo in content.Select((value, index) => new { value.Name, value.Path, Index = index + startIndex } ))
+
+			foreach( var dirInfo in content.Select((value, index) => new { value.Name, value.Path, FullPath = value.GetFullPath(), Index = index + startIndex } ))
 			{
 				if( dirInfo.Name != "" )
 				{
-					try
-					{
-						// for each folder, add its index to its parent folder list of subdirs
-                        // The ID for each folder is equal to the index in the JS data array
-						subdirs[dirInfo.Path].Add( dirInfo.Index.ToString() );
-					}
-					catch( Exception ex )
-					{
-						// orphan file or folder?
-					}
+                    // for each folder, add its index to its parent folder list of subdirs
+                    // The ID for each folder is equal to the index in the JS data array
+                    if( subdirs.TryGetValue( dirInfo.Path, out var subfolderIds ) )
+                    {
+                        subfolderIds.Add( dirInfo.Index.ToString() );
+                    }
+                    else
+                    {
+                        subdirs.Add( dirInfo.Path, new List<string>() { dirInfo.Index.ToString() } );
+                    }
+
+					// all folders must exist as key, also those without children
+                    if( !subdirs.ContainsKey( dirInfo.FullPath ) )
+                    {
+                        subdirs.Add( dirInfo.FullPath, new List<string>() );
+                    }
 				}
 			}
 

--- a/Snap2HTML/frmMain_BackgroundWorker.cs
+++ b/Snap2HTML/frmMain_BackgroundWorker.cs
@@ -31,7 +31,7 @@ namespace Snap2HTML
 
 			// Calculate some stats
 			int totDirs = 0;
-			int totFiles = 0;
+			long totFiles = 0;
 			long totSize = 0;
 			foreach( var folder in content )
 			{

--- a/Snap2HTML/frmMain_BackgroundWorker.cs
+++ b/Snap2HTML/frmMain_BackgroundWorker.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Snap2HTML
 {
-    public partial class frmMain : Form
+	public partial class frmMain : Form
 	{
 		// This runs on a separate thread from the GUI
 		private void backgroundWorker_DoWork( object sender, DoWorkEventArgs e )

--- a/Snap2HTML/frmMain_BackgroundWorker.cs
+++ b/Snap2HTML/frmMain_BackgroundWorker.cs
@@ -1,17 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.Text;
 using System.Windows.Forms;
-using CommandLine.Utility;
 using System.IO;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Snap2HTML
 {
-	public partial class frmMain : Form
+    public partial class frmMain : Form
 	{
 		// This runs on a separate thread from the GUI
 		private void backgroundWorker_DoWork( object sender, DoWorkEventArgs e )
@@ -349,13 +347,6 @@ namespace Snap2HTML
 
 			var lineBreakSymbol = "";	// Could be set to \n to make the html output more readable, at the expense of increased size
 
-			// Assign an ID to each folder. This is equal to the index in the JS data array
-			var dirIndexes = new Dictionary<string, string>();
-			for( var i = 0; i < content.Count; i++ )
-			{
-				dirIndexes.Add( content[i].GetFullPath(), ( i + startIndex ).ToString() );
-			}
-
 			// Build a lookup table with subfolder IDs for each folder
 			var subdirs = new Dictionary<string, List<string>>();
 			foreach( var dir in content )
@@ -368,14 +359,15 @@ namespace Snap2HTML
 				// ensure that root folder is not missed missed
 				subdirs.Add( content[0].Path, new List<string>() );
 			}
-			foreach( var dir in content )
+			foreach( var dirInfo in content.Select((value, index) => new { value.Name, value.Path, Index = index + startIndex } ))
 			{
-				if( dir.Name != "" )
+				if( dirInfo.Name != "" )
 				{
 					try
 					{
 						// for each folder, add its index to its parent folder list of subdirs
-						subdirs[dir.Path].Add( dirIndexes[dir.GetFullPath()] );
+                        // The ID for each folder is equal to the index in the JS data array
+						subdirs[dirInfo.Path].Add( dirInfo.Index.ToString() );
 					}
 					catch( Exception ex )
 					{

--- a/Snap2HTML/frmMain_BackgroundWorker.cs
+++ b/Snap2HTML/frmMain_BackgroundWorker.cs
@@ -346,32 +346,25 @@ namespace Snap2HTML
 			// Build a lookup table with subfolder IDs for each folder
 			var subdirs = new Dictionary<string, List<string>>();
 
-			if( !subdirs.ContainsKey( content[0].Path ) && content[0].Name != "" )
-			{
-				// ensure that root folder is not missed missed
-				subdirs.Add( content[0].Path, new List<string>() );
-			}
-
 			foreach( var dirInfo in content.Select((value, index) => new { value.Name, value.Path, FullPath = value.GetFullPath(), Index = index + startIndex } ))
 			{
-				if( dirInfo.Name != "" )
+				// for each folder, add its index to its parent folder list of subdirs
+				// The ID for each folder is equal to the index in the JS data array
+				if( subdirs.TryGetValue( dirInfo.Path, out var subfolderIds ) )
 				{
-                    // for each folder, add its index to its parent folder list of subdirs
-                    // The ID for each folder is equal to the index in the JS data array
-                    if( subdirs.TryGetValue( dirInfo.Path, out var subfolderIds ) )
-                    {
-                        subfolderIds.Add( dirInfo.Index.ToString() );
-                    }
-                    else
-                    {
-                        subdirs.Add( dirInfo.Path, new List<string>() { dirInfo.Index.ToString() } );
-                    }
+					subfolderIds.Add( dirInfo.Index.ToString() );
+				}
+				else
+				{
+					// the root may not reference itself in the JS output
+					bool isDiskRoot = dirInfo.Name == string.Empty;
+					subdirs.Add( dirInfo.Path, isDiskRoot ? new List<string>() : new List<string>() { dirInfo.Index.ToString() } );
+				}
 
-					// all folders must exist as key, also those without children
-                    if( !subdirs.ContainsKey( dirInfo.FullPath ) )
-                    {
-                        subdirs.Add( dirInfo.FullPath, new List<string>() );
-                    }
+				// all folders must exist as key, also those without children
+				if( !subdirs.ContainsKey( dirInfo.FullPath ) )
+				{
+					subdirs.Add( dirInfo.FullPath, new List<string>() );
 				}
 			}
 

--- a/Snap2HTML/frmMain_BackgroundWorker.cs
+++ b/Snap2HTML/frmMain_BackgroundWorker.cs
@@ -179,11 +179,7 @@ namespace Snap2HTML
 				{
 					// Get folder properties
 					var dirName = dirs[d];
-					var currentDir = new SnappedFolder( Path.GetFileName( dirName ), Path.GetDirectoryName( dirName ) );
-					if( dirName == Path.GetPathRoot( dirName ) )
-					{
-						currentDir = new SnappedFolder( "", dirName );
-					}
+					var currentDir = new SnappedFolder( Path.GetFileName( dirName ), Path.GetDirectoryName( dirName ) ?? dirName );
 
 					modified_date = "";
 					created_date = "";


### PR DESCRIPTION
These changes fix bug #22 where the application crashes.

I'm not sure why exactly it went wrong, but I rewrote the failing part. Adding a test before trying to insert a new key avoids to have the same problem again. Some unneeded loops are removed. Tested on empty folders/disks and still works as expected, and tested by 3rd party that had the same error.