### PR TITLE
Added custom icons for regular file types + typo fixes

### DIFF
--- a/Snap2HTML/frmMain_BackgroundWorker.cs
+++ b/Snap2HTML/frmMain_BackgroundWorker.cs
@@ -365,7 +365,7 @@ namespace Snap2HTML
 			}
 			if( !subdirs.ContainsKey( content[0].Path ) && content[0].Name != "" )
 			{
-				// ensure that root folder is not missed missed
+				// ensure that root folder is not missed
 				subdirs.Add( content[0].Path, new List<string>() );
 			}
 			foreach( var dir in content )

--- a/Snap2HTML/template.html
+++ b/Snap2HTML/template.html
@@ -287,6 +287,39 @@
 			color: #900;
 		}
 
+		span.mp4, span.avi, span.flv, span.swf, span.mov, span.mpg, span.mkv, span.webm, span.wmv {	
+			background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAB3RJTUUH5ggTERYzwLn8CQAAABN0RVh0U29mdHdhcmUAUGhvdG9TY2FwZYB1kb8AAAD+SURBVDhPzdIxS0JRGMbxqwZ+AIlWpxRdbGyI3CJocU1chGh10qbCSQmKiiCwgqBBxIZqiRqihLDCwYa2Pkz/B7xw73uu+33gx4EX7jnvec/1YpnEbF0w/Lq/OllEB694w4PxghGuUISTA1SxizNkjDousIJLJBHKNfp4wp4KJmVMcYoPOBuotR200VTBZA13WMczUghFbTVwiHtsG8d4xBY0D2eDHm6ggX1CHwSpPkEX74icwSpqaKlgotbPkYY60dOGohmotS/MG+IfBhjD6eAEFei++yqYbOIIWQzhbFCA3vkbP9BJQfqJfnGLDURmCXnkUDJ0wDLUQWzief+8ETZNSP5mNQAAAABJRU5ErkJggg==)	
+						no-repeat	
+						left center;				
+		}	
+		span.pdf, span.docx, span.doc, span.ppt, span.pptx, span.xls, span.xlsx, span.rtf, span.txt {	
+			background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAB3RJTUUH5ggYAx8VC9UyogAAABN0RVh0U29mdHdhcmUAUGhvdG9TY2FwZYB1kb8AAADbSURBVDhPrdFPi0FRHMbxK4WlYraysEPZkSZl/MlOssRSWSoLUZQ/o8RoZmmmZuNVeBXeg1fi+8y9V5N7seCpT53O7fR7zrnGM+NHwOLRxr340MYOv5Y9OriZDLYIwZ64xgFNXE0FM3N5zgg61ENDG24p491cnhPHJ75wRB2OlDBHAgVLFknk0YWqO1LEFC18WBYIQ3nFZaO/aKLuWMUAY2jCD3LQdNeDuuMEeoQV9Bvs1/VC1dXAkTdsEEUKEfxPDa4TX7CEPvYxhKrbvpGGa4JQJdW+FMOjMYwTs58iHmN9hacAAAAASUVORK5CYII=)	
+						no-repeat	
+						left center;				
+		}			
+		span.jpg, span.jpeg, span.png, span.bmp, span.psd, span.jp2, span.gif, span.tif, span.tiff, span.ico, span.svg {	
+			background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAB3RJTUUH5ggYAxky+IUgTwAAABN0RVh0U29mdHdhcmUAUGhvdG9TY2FwZYB1kb8AAAEPSURBVDhPzdKxSgNBFEbhUWMQNCgYrGy1SGljJagRfQIbSwt9BCstBCEoWCgiCtGkVhDFIkQLH0DbPI/nZBPZdVZSBfzhg1mWvXPnzoZ/lXHsoz7AEcqI4seX2MJGjmWswAI1RLnHZrLMzRLmUMIrCsjkDqvJMsokOjjoPoXwgqjALarYwzGcST+jWMR0zzOiAjewtQtc4wQT6MfWFzCFJ0QFnMEbZuDu53BY7u7Zm/D9Nh4whky8ovQQPfcpvBm724U38Y5PRLHAWrL8SRFXaPfWZh0fsLNMGvhdwHhWhyrXHi93iP4gh/C8synOZB7O6Aw78MZGkIm/p0Pzjt0h7REtfMFOK/gztpZnGAnhG/orL+xjmiJ5AAAAAElFTkSuQmCC)	
+						no-repeat	
+						left center;				
+		}					
+			
+		span.mp3, span.wav, span.wma, span.flac, span.ogg, span.m4a {	
+			background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAOCAQAAACxtDVnAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAHdElNRQfmCBoXBx6vOrBUAAAAkklEQVQY04XQvQ4BYRSE4WfZRCPRqEUpUUqIn9aWLkeF+yBxCRoNV6BUa5DQqzQ0NB/Z3Uic0807M8k5kewUNbT0taMgVPR19bSVwfPjnHil9u5RyFWdLIxUib/S3tzWBURpsLZIR/NV/0H801z/lWg5O4piDCQ6dgFM1XBgGo6aBZDYWKpxC2CYf1pJ09XYKgveqe8ijbJPSOgAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjItMDgtMjZUMjM6MDc6MzArMDA6MDCcN/8tAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIyLTA4LTI2VDIzOjA3OjMwKzAwOjAw7WpHkQAAAABJRU5ErkJggg==)	
+						no-repeat	
+						left center;				
+		}	
+			
+		span.exe {	
+			background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAB3RJTUUH5ggYAyEZQ6Zl9AAAABN0RVh0U29mdHdhcmUAUGhvdG9TY2FwZYB1kb8AAADlSURBVDhPvdHPSkJBFIDxsTa9gNhb1L6l4FJwl+ugICrFsigMoj9u1JKiAn3Zvu965pJIuJEO/Dic4Z47Z2bSpmJnjW0sxS6GmGKMN8wjW2ffOEAZPVziCCMcoxrZWg9oweZy5zsM8IF65JvI+6GLJ0zg2EX4kQvXRbWoncDRT4Ojmh1/qdFxbosqpUe4cxN51D4cf4Y/Gx29A0d1TZ84wcqOr5GNK3xFzrEHL8YNysZ7nMMz2fyOBvIl5TVv3bWy8RD+6SzyBTyj2Vo+hxf2ggqK2EIbPonnMT//quW5bazh3yOlHxVGNMtaDBCOAAAAAElFTkSuQmCC)	
+						no-repeat	
+						left center;				
+		}				
+		span.zip, span.rar {	
+			background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAB3RJTUUH5ggYAyU78qrhFAAAABN0RVh0U29mdHdhcmUAUGhvdG9TY2FwZYB1kb8AAADFSURBVDhPrdLPCgFRFMfxkfyLhYUHUB7BQtkIRXkMWVrYigXJwsbaygLlTaw8lO/vnjs0mjGKX33qzK3bOXNmgn8ki2KKAiLp4IxjihOmyMBlh5GVH1PCFerussAM/S+ocx4uDdyhzlusMPeW/kxumOAZLeZgpUsZTa+uAx9N1rXSopk1Qjh7G2GXsQ58NhhYaXm/mJTEizn3lJw1hlZatKULKu4pOXv0rHxF29KCNE4cXdLWa4hEf0MLeoc4+oZV/JIgeABYYCOd/CRLTwAAAABJRU5ErkJggg==)	
+						no-repeat	
+						left center;				
+		}					
+
 		td.size {
 			text-align: right;
 			white-space: nowrap;
@@ -789,7 +822,7 @@
 						Note that forward slashes are used instead of (Windows style) backslashes
 					Then, for each each file in the directory: "filename*size of file*file modified date"
 					Second to last item in array tells the total size of directory content
-					Last item in array refrences IDs to all subdirectories of this dir (if any).
+					Last item in array references IDs to all subdirectories of this dir (if any).
 						ID is the item index in dirs array.
 				Note: Modified date is in UNIX format
 						
@@ -1130,10 +1163,10 @@
 							countFiles++;
 
 							var file_tmp = SearchFilenames[index][3];
+							var ext = file_tmp.split('.').pop()
 
 							if( linkFiles )
 							{
-								var ext = file_tmp.split('.').pop();
 								if(onlyLinkExtensions.length === 0 || onlyLinkExtensions.indexOf(ext) !== -1) {
 
 									file_tmp = linkProtocol + linkRoot + dir_tmp.replace("\\","/") + SearchFilenames[index][3] + "\">";
@@ -1173,7 +1206,7 @@
 							var timestamp = timestampToDate(SearchFilenames[index][2]);
 							table_html += 
 								"<tr>" + 
-									"<td><span class='file'>" + file_tmp + "</span></td>" + 
+									"<td><span class='file " + ext + "'>" + file_tmp + "</span></td>" + 
 									locationHtml + 
 									"<td class='size' data-sort='" + SearchFilenames[index][1] + "'>" + bytesToSize( SearchFilenames[index][1] ) + "</td>" + 
 									"<td class='date' data-sort='" + SearchFilenames[index][2] + "'>" + timestamp + "</td>" + 
@@ -1308,10 +1341,10 @@
 					var file_tmp = sTmp[0];
 					var dir_tmp = getDirNameAndPath(SelectedFolderID).substring(sourceRoot.length);
 					if( dir_tmp != "" ) dir_tmp += "/";
+					var ext = file_tmp.split('.').pop()
 					if( linkFiles )
 					{
 
-						var ext = file_tmp.split('.').pop();
 						if(onlyLinkExtensions.length === 0 || onlyLinkExtensions.indexOf(ext) !== -1) {
 							file_tmp = linkProtocol + linkRoot + dir_tmp + sTmp[0] + "\">";
 							if( navigator.userAgent.toLowerCase().indexOf("msie") !== -1  &&  linkProtocol.indexOf("file:") !== -1 )
@@ -1343,7 +1376,7 @@
 
 					table_html += 
 						"<tr>" + 
-							"<td><span class='file'>" + file_tmp + "</span></td>" + 
+							"<td><span class='file " + ext + "'>" + file_tmp + "</span></td>" + 
 							"<td class='size' data-sort='" + sTmp[1] + "'>" + bytesToSize( sTmp[1] ) + "</td>" + 
 							"<td class='date' data-sort='" + sTmp[2] + "'>" + timestamp + "</td>" + 
 						"</tr>\n";
@@ -1723,7 +1756,7 @@
 			</form>
 
 			<h1>[TITLE]</h1>
-			<div class="app_header_stats">[NUM FILES] files in [NUM DIRS] folders (<span id="tot_size">[TOT SIZE]</span>)<br>Generated [GEN DATE] [GEN TIME] by <a href="[APP LINK]">[APP NAME]</a></div>
+			<div class="app_header_stats">📄[NUM FILES] files in 📂[NUM DIRS] folders (<span id="tot_size">[TOT SIZE]</span>)<br>Generated [GEN DATE] [GEN TIME] by <a href="[APP LINK]">[APP NAME]</a></div>
 
 		</div>
 


### PR DESCRIPTION
- Added icons to page header
![image](https://user-images.githubusercontent.com/22286863/187718412-31176e09-0c1e-4a5a-a40d-07afc8ef3a33.png)
- Fixed typos in code comments
- Added custom icons for common file types ⭐
    -  mp4, avi, flv, swf, mov, mpg, mkv, webm, wmv 
![film](https://user-images.githubusercontent.com/22286863/187721351-2f709652-12c0-4110-8a4f-f60aa70af412.png)

    -  pdf, docx, doc, ppt, pptx, xls, xlsx, rtf, txt
![document](https://user-images.githubusercontent.com/22286863/187720346-72d3e111-c981-45ab-ae4d-1d3bf2e9408a.png)

    -  jpg, jpeg, png, bmp, psd, jp2, gif, tif, tiff, ico, svg
![picture 16x16](https://user-images.githubusercontent.com/22286863/187720250-dbdb41aa-1135-4ddc-8518-80ce906890c5.png)

    -  mp3, wav, wma, flac, ogg, m4a
![music-icon 14x14](https://user-images.githubusercontent.com/22286863/187720094-746ee0e8-abb3-42bc-a482-f1269f0363fd.png)

    -  exe
![browser_alt](https://user-images.githubusercontent.com/22286863/187720286-7717c4f1-e3a5-49ce-ab6d-ff03b749fc63.png)

    -  zip, rar
  ![archive-line-icon 14x14](https://user-images.githubusercontent.com/22286863/187719890-9b85b295-c370-41a5-9908-44ab507447db.png)

![image](https://user-images.githubusercontent.com/22286863/187722400-3a442c0e-9cb9-47e7-8f50-b57774f77c92.png)


All icons were obtained from [System UIcons](https://systemuicons.com/) and [UXWing](https://uxwing.com/) which are open source and **free for personal/comerical use without attribution**.